### PR TITLE
Add formatCellphone

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -3035,6 +3035,25 @@ Format string in a printf-like format.
 format('%s_%s', 'foo', 'bar'); // -> 'foo_bar'
 ```
 
+## formatCellphone 
+
+Format a cellphone number into international format or local format.
+
+|Name               |Type   |Desc                                                  |
+|-------------------|-------|------------------------------------------------------|
+|cellphoneNumber    |string |cellphone number to format                            |
+|internationalString|string |international string used for cellphone number        |
+|international=false|boolean|should the number be converted to international format|
+|return             |string |new formatted cellphone number                        |
+
+```javascript
+formatCellphone('0820000001', '+27', true);   // -> '+27820000001'
+formatCellphone('0820000001', '+27');         // -> '0820000001'
+formatCellphone('+27820000001', '+27', true); // -> '+27820000001'
+formatCellphone('+27820000001', '+27');       // -> '0820000001'
+formatCellphone('820000001', '+27');       // -> '820000001'
+```
+
 ## fraction 
 
 Convert number to fraction.

--- a/DOC_CN.md
+++ b/DOC_CN.md
@@ -3031,6 +3031,25 @@ fnParams(function (a, b) {}); // -> ['a', 'b']
 format('%s_%s', 'foo', 'bar'); // -> 'foo_bar'
 ```
 
+## formatCellphone
+
+Format a cellphone number into international format or local format.
+
+|Name               |Type   |Desc                                                  |
+|-------------------|-------|------------------------------------------------------|
+|cellphoneNumber    |string |cellphone number to format                            |
+|internationalString|string |international string used for cellphone number        |
+|international=false|boolean|should the number be converted to international format|
+|return             |string |new formatted cellphone number                        |
+
+```javascript
+formatCellphone('0820000001', '+27', true);   // -> '+27820000001'
+formatCellphone('0820000001', '+27');         // -> '0820000001'
+formatCellphone('+27820000001', '+27', true); // -> '+27820000001'
+formatCellphone('+27820000001', '+27');       // -> '0820000001'
+formatCellphone('820000001', '+27');       // -> '820000001'
+```
+
 ## fraction
 
 转换数字为分数形式。

--- a/index.json
+++ b/index.json
@@ -2098,6 +2098,19 @@
             "browser"
         ]
     },
+    "formatCellphone": {
+        "description": "Format a cellphone number into international format or local format.",
+        "dependencies": [],
+        "env": [
+            "node",
+            "browser",
+            "miniprogram"
+        ],
+        "test": [
+            "node",
+            "browser"
+        ]
+    },
     "fraction": {
         "description": "Convert number to fraction.",
         "dependencies": [

--- a/src/f/formatCellphone.js
+++ b/src/f/formatCellphone.js
@@ -13,6 +13,7 @@
  * formatCellphone('0820000001', '+27');         // -> '0820000001'
  * formatCellphone('+27820000001', '+27', true); // -> '+27820000001'
  * formatCellphone('+27820000001', '+27');       // -> '0820000001'
+ * formatCellphone('820000001', '+27');       // -> '820000001'
  */
 
 /* module
@@ -34,4 +35,5 @@ exports = function (cellNumber, internationalString, internationFormat = false) 
   if (cellNumber.indexOf(internationalString) === 0) {
     return internationFormat ? cellNumber : `0${cellNumber.replace(internationalString, '')}`;
   }
+  return internationFormat ? `${internationalString}${cellNumber}` : cellNumber;
 }

--- a/src/f/formatCellphone.js
+++ b/src/f/formatCellphone.js
@@ -1,0 +1,37 @@
+/* Format a cellphone number into international format or local format.
+ *
+ * |Name               |Type   |Desc                                                  |
+ * |-------------------|-------|------------------------------------------------------|
+ * |cellphoneNumber    |string |cellphone number to format                            |
+ * |internationalString|string |international string used for cellphone number        |
+ * |international=false|boolean|should the number be converted to international format|
+ * |return             |string |new formatted cellphone number                        |
+ */
+
+/* example
+ * formatCellphone('0820000001', '+27', true);   // -> '+27820000001'
+ * formatCellphone('0820000001', '+27');         // -> '0820000001'
+ * formatCellphone('+27820000001', '+27', true); // -> '+27820000001'
+ * formatCellphone('+27820000001', '+27');       // -> '0820000001'
+ */
+
+/* module
+ * env: all
+ * test: all
+ */
+
+/* typescript
+ * export declare function formatCellphone(
+ *     cellphoneNumber: string,
+ *     internationalString: string
+ * ): string;
+ */
+
+exports = function (cellNumber, internationalString, internationFormat = false) {
+  if (cellNumber[0] === '0') {
+    return internationFormat ? `${internationalString}${cellNumber.slice(1)}` : cellNumber;
+  }
+  if (cellNumber.indexOf(internationalString) === 0) {
+    return internationFormat ? cellNumber : `0${cellNumber.replace(internationalString, '')}`;
+  }
+}

--- a/src/f/formatCellphone.js
+++ b/src/f/formatCellphone.js
@@ -36,4 +36,4 @@ exports = function (cellNumber, internationalString, internationFormat = false) 
     return internationFormat ? cellNumber : `0${cellNumber.replace(internationalString, '')}`;
   }
   return internationFormat ? `${internationalString}${cellNumber}` : cellNumber;
-}
+};

--- a/src/f/formatCellphone.js
+++ b/src/f/formatCellphone.js
@@ -24,16 +24,17 @@
 /* typescript
  * export declare function formatCellphone(
  *     cellphoneNumber: string,
- *     internationalString: string
+ *     internationalString: string,
+ *     international?: boolean
  * ): string;
  */
 
-exports = function (cellNumber, internationalString, internationFormat = false) {
+exports = function (cellNumber, internationalString, international = false) {
   if (cellNumber[0] === '0') {
-    return internationFormat ? `${internationalString}${cellNumber.slice(1)}` : cellNumber;
+    return international ? `${internationalString}${cellNumber.slice(1)}` : cellNumber;
   }
   if (cellNumber.indexOf(internationalString) === 0) {
-    return internationFormat ? cellNumber : `0${cellNumber.replace(internationalString, '')}`;
+    return international ? cellNumber : `0${cellNumber.replace(internationalString, '')}`;
   }
-  return internationFormat ? `${internationalString}${cellNumber}` : cellNumber;
+  return international ? `${internationalString}${cellNumber}` : cellNumber;
 };

--- a/src/f/formatCellphone.test.js
+++ b/src/f/formatCellphone.test.js
@@ -14,7 +14,7 @@ it('international', function () {
   expect(formatCellphone('+44820000000', '+44')).to.equal('0820000000');
   expect(formatCellphone('+59342111111', '+593', true)).to.equal('+59342111111');
   expect(formatCellphone('+59342111111', '+593')).to.equal('042111111');
-})
+});
 
 it('local', function() {
   expect(formatCellphone('820000000', '+27', true)).to.equal('+27820000000');
@@ -23,4 +23,4 @@ it('local', function() {
   expect(formatCellphone('820000000', '+44')).to.equal('820000000');
   expect(formatCellphone('42111111', '+593', true)).to.equal('+59342111111');
   expect(formatCellphone('42111111', '+593')).to.equal('42111111');
-})
+});

--- a/src/f/formatCellphone.test.js
+++ b/src/f/formatCellphone.test.js
@@ -1,0 +1,26 @@
+it('basic', function () {
+  expect(formatCellphone('0820000000', '+27', true)).to.equal('+27820000000');
+  expect(formatCellphone('0820000000', '+27')).to.equal('0820000000');
+  expect(formatCellphone('0820000000', '+44', true)).to.equal('+44820000000');
+  expect(formatCellphone('0820000000', '+44')).to.equal('0820000000');
+  expect(formatCellphone('042111111', '+593', true)).to.equal('+59342111111');
+  expect(formatCellphone('042111111', '+593')).to.equal('042111111');
+});
+
+it('international', function () {
+  expect(formatCellphone('+27820000000', '+27', true)).to.equal('+27820000000');
+  expect(formatCellphone('+27820000000', '+27')).to.equal('0820000000');
+  expect(formatCellphone('+44820000000', '+44', true)).to.equal('+44820000000');
+  expect(formatCellphone('+44820000000', '+44')).to.equal('0820000000');
+  expect(formatCellphone('+59342111111', '+593', true)).to.equal('+59342111111');
+  expect(formatCellphone('+59342111111', '+593')).to.equal('042111111');
+})
+
+it('local', function() {
+  expect(formatCellphone('820000000', '+27', true)).to.equal('+27820000000');
+  expect(formatCellphone('820000000', '+27')).to.equal('820000000');
+  expect(formatCellphone('820000000', '+44', true)).to.equal('+44820000000');
+  expect(formatCellphone('820000000', '+44')).to.equal('820000000');
+  expect(formatCellphone('42111111', '+593', true)).to.equal('+59342111111');
+  expect(formatCellphone('42111111', '+593')).to.equal('42111111');
+})


### PR DESCRIPTION
Add function that can format a cell phone number to international format or local format. This is quite useful in the case when working with a frontend that expects local formats and a backend that expects a international format when working with services like Twilio which use the international formats.