### PR TITLE
Only add query parameters if they are necessary

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -134,7 +134,7 @@ exports = function(options) {
 
     if (type === 'GET') {
         data = query.stringify(data);
-        url += url.indexOf('?') > -1 ? '&' + data : '?' + data;
+        if (data) url += url.indexOf('?') > -1 ? '&' + data : '?' + data;
     } else if (options.contentType === 'application/x-www-form-urlencoded') {
         if (isObj(data)) data = query.stringify(data);
     } else if (options.contentType === 'application/json') {


### PR DESCRIPTION
This was necessary for eruda to correctly view the source of blob URLs