### PR TITLE
Add TypeScript type files and ES module packages in the mini-program environment.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -12,6 +12,7 @@ const {
     regDependencies,
     extractDependencies
 } = require('./util');
+const packInfo = require('../package.json');
 
 module.exports = async function() {
     try {
@@ -27,6 +28,7 @@ module.exports = async function() {
         await genPackage('licia', files);
         await genPackage('licia-es', files);
         await genPackage('miniprogram-licia', files);
+        await genPackage('miniprogram-licia-es', files);
     } catch (e) {
         console.log(e);
         return;
@@ -35,7 +37,7 @@ module.exports = async function() {
 
 async function genPackage(pkgName, files) {
     await mkdir('packages/' + pkgName);
-    if (pkgName === 'miniprogram-licia') {
+    if (pkgName === 'miniprogram-licia' || pkgName === 'miniprogram-licia-es') {
         await mkdir(`packages/${pkgName}/miniprogram_dist`);
     }
     for (const file of files) {
@@ -58,9 +60,13 @@ async function genPackage(pkgName, files) {
         }
         await genIndex(pkgName);
     }
-    if (pkgName === 'miniprogram-licia') {
+    if (pkgName === 'miniprogram-licia' || pkgName === 'miniprogram-licia-es') {
         packInfo.main = 'miniprogram_dist/index.js';
         packInfo.miniprogram = 'miniprogram_dist';
+        packInfo.typings = 'miniprogram_dist/index.d.ts';
+        if (pkgName === 'miniprogram-licia-es') {
+            packInfo.sideEffects = false;
+        }
         await genIndex(pkgName);
     }
 
@@ -75,7 +81,7 @@ async function genIndex(pkgName) {
     const mods = {
         browser: [],
         node: [],
-        miniprogram: []
+        miniprogram: [],
     };
 
     each(modData, (mod, modName) => {
@@ -124,13 +130,27 @@ async function genIndex(pkgName) {
         );
     } else {
         const modNames = mods.miniprogram;
+        const isMiniProgram = pkgName === 'miniprogram-licia' || pkgName === 'miniprogram-licia-es';
         let data = '';
+        let tsData = '';
         each(modNames, name => {
-            data += `exports.${name} = require('./${name}');\n`;
+            if (isMiniProgram) {
+                data += `export { default as ${name} } from './${name}';\n`;
+            } else {
+                data += `exports.${name} = require('./${name}');\n`;
+            }
+            tsData += `export { default as ${name} } from './${name}';\n`;
         });
+        if (isMiniProgram) {
+            await fs.writeFile(
+                path.resolve(`.licia/packages/${pkgName}/miniprogram_dist/index.d.ts`),
+                tsData,
+                'utf8'
+            );
+        }
         await fs.writeFile(
             path.resolve(
-                `.licia/packages/miniprogram-licia/miniprogram_dist/index.js`
+                `.licia/packages/${pkgName}/miniprogram_dist/index.js`
             ),
             data,
             'utf8'
@@ -145,10 +165,11 @@ async function genFile(file, pkgName) {
 
     const env = modData[modName].env;
     const isEs5 = contain(env, 'browser') || contain(env, 'miniprogram');
-    if (isEs5 && pkgName !== 'licia-src' && pkgName !== 'licia-es') {
+    const isMiniProgram = pkgName === 'miniprogram-licia' || pkgName === 'miniprogram-licia-es';
+    if (isEs5 && pkgName !== 'licia-src' && pkgName !== 'licia-es' && pkgName !== 'miniprogram-licia-es') {
         data = await transBabel(data);
     }
-    if (pkgName === 'miniprogram-licia') {
+    if (pkgName === 'miniprogram-licia' || pkgName === 'miniprogram-licia-es') {
         if (!contain(env, 'miniprogram')) {
             return;
         }
@@ -165,7 +186,7 @@ async function genFile(file, pkgName) {
         );
     } else {
         const dependencies = extractDependencies(data);
-        if (pkgName === 'licia-es') {
+        if (pkgName === 'licia-es' || pkgName === 'miniprogram-licia-es') {
             data = transToEsModule(
                 data,
                 filter(dependencies, dep => dep !== 'types')
@@ -178,7 +199,7 @@ async function genFile(file, pkgName) {
             );
         }
 
-        if (pkgName === 'licia' || pkgName === 'licia-es') {
+        if (pkgName === 'licia' || pkgName === 'licia-es' || isMiniProgram) {
             const tsDefinition = extractTsDefinition(
                 pkgName,
                 data,
@@ -186,9 +207,10 @@ async function genFile(file, pkgName) {
                 dependencies
             );
             if (tsDefinition) {
+
                 await fs.writeFile(
                     path.resolve(
-                        './.licia/packages/' + pkgName,
+                        './.licia/packages/' + pkgName + (isMiniProgram ? '/miniprogram_dist/' : ''),
                         modName + '.d.ts'
                     ),
                     tsDefinition,
@@ -205,7 +227,7 @@ async function genFile(file, pkgName) {
             './.licia/packages/' + pkgName,
             modName + '.js'
         );
-        if (pkgName === 'miniprogram-licia') {
+        if (isMiniProgram) {
             outputPath = path.resolve(
                 `./.licia/packages/${pkgName}/miniprogram_dist`,
                 modName + '.js'


### PR DESCRIPTION
问题场景：
        基于 Taro Vue3 TypeScript 开发小程序，使用 `miniprogram-licia`，导入依赖，会缺少TS类型提示(没有对应的.d.ts文件)。该包基于commonjs打包，导入一个函数，整个模块全给导入进来了。

增加功能：
1. miniprogram-licia 打包输入增加对应 `.d.ts` 文件
2. 增加了 `miniprogram-licia-es` 包，使用es模块输出的小程序包，提供和功能和`miniprogram-licia`保持一致