### PR TITLE
feat: generate TypeScript declarations for miniprogram-licia

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -61,6 +61,7 @@ async function genPackage(pkgName, files) {
     if (pkgName === 'miniprogram-licia') {
         packInfo.main = 'miniprogram_dist/index.js';
         packInfo.miniprogram = 'miniprogram_dist';
+        packInfo.typings = 'miniprogram_dist/index.d.ts';
         await genIndex(pkgName);
     }
 
@@ -125,14 +126,23 @@ async function genIndex(pkgName) {
     } else {
         const modNames = mods.miniprogram;
         let data = '';
+        let tsData = '';
         each(modNames, name => {
             data += `exports.${name} = require('./${name}');\n`;
+            tsData += `export import ${name} = require('./${name}');\n`;
         });
         await fs.writeFile(
             path.resolve(
                 `.licia/packages/miniprogram-licia/miniprogram_dist/index.js`
             ),
             data,
+            'utf8'
+        );
+        await fs.writeFile(
+            path.resolve(
+                `.licia/packages/miniprogram-licia/miniprogram_dist/index.d.ts`
+            ),
+            tsData,
             'utf8'
         );
     }
@@ -178,7 +188,7 @@ async function genFile(file, pkgName) {
             );
         }
 
-        if (pkgName === 'licia' || pkgName === 'licia-es') {
+        if (pkgName === 'licia' || pkgName === 'licia-es' || pkgName === 'miniprogram-licia') {
             const tsDefinition = extractTsDefinition(
                 pkgName,
                 data,
@@ -186,14 +196,17 @@ async function genFile(file, pkgName) {
                 dependencies
             );
             if (tsDefinition) {
-                await fs.writeFile(
-                    path.resolve(
-                        './.licia/packages/' + pkgName,
-                        modName + '.d.ts'
-                    ),
-                    tsDefinition,
-                    'utf-8'
+                let tsOutputPath = path.resolve(
+                    './.licia/packages/' + pkgName,
+                    modName + '.d.ts'
                 );
+                if (pkgName === 'miniprogram-licia') {
+                    tsOutputPath = path.resolve(
+                        `./.licia/packages/${pkgName}/miniprogram_dist`,
+                        modName + '.d.ts'
+                    );
+                }
+                await fs.writeFile(tsOutputPath, tsDefinition, 'utf-8');
             }
         }
 
@@ -298,7 +311,7 @@ function transBabel(data) {
 function extractTsDefinition(pkgName, data, modName, dependencies) {
     let tsDefinition = extractComment(data, 'typescript');
     tsDefinition = tsDefinition.replace(/export declare/g, 'declare');
-    if (pkgName === 'licia') {
+    if (pkgName === 'licia' || pkgName === 'miniprogram-licia') {
         tsDefinition += '\n\nexport = ' + modName + ';';
     } else {
         tsDefinition += '\n\nexport default ' + modName + ';';
@@ -311,7 +324,7 @@ function extractTsDefinition(pkgName, data, modName, dependencies) {
         each(dependencies, (val, i) => {
             if (!contain(tsDefinition, val)) return;
 
-            if (pkgName === 'licia') {
+            if (pkgName === 'licia' || pkgName === 'miniprogram-licia') {
                 imports += 'import ' + val + " = require('./" + val + "');";
             } else {
                 imports += 'import ' + val + " from './" + val + "';";


### PR DESCRIPTION
miniprogram-licia is missing .d.ts type declarations. This PR adds TypeScript type generation for it during the build process, consistent with how licia and licia-es already handle types.