### PR TITLE
Avoid shell execution in kill

### DIFF
--- a/src/kill.js
+++ b/src/kill.js
@@ -18,19 +18,28 @@
  * export declare function kill(pid: number): void;
  */
 
-_('isWindows');
+_('isWindows isInt toNum');
 
 const childProcess = require('child_process');
 
 exports = function(pid) {
     try {
-        let cmd = '';
-        if (isWindows) {
-            cmd = `taskkill /pid ${pid} /T /F`;
-        } else {
-            cmd = `kill ${pid} -9`;
+        pid = toNum(pid);
+        if (!isInt(pid) || pid <= 0) {
+            throw new TypeError('Invalid pid');
         }
-        childProcess.execSync(cmd);
+
+        if (isWindows) {
+            childProcess.spawnSync(
+                'taskkill',
+                ['/pid', String(pid), '/T', '/F'],
+                {
+                    stdio: 'ignore'
+                }
+            );
+        } else {
+            process.kill(pid, 'SIGKILL');
+        }
     } catch (e) {
         /* eslint-disable no-empty */
     }

--- a/test/kill.js
+++ b/test/kill.js
@@ -11,3 +11,37 @@ it('basic', done => {
 
     kill(subProcess.pid);
 });
+
+it('only accepts numeric pids', () => {
+    const childProcess = require('child_process');
+    const originalProcessKill = process.kill;
+    const originalSpawnSync = childProcess.spawnSync;
+    let called = false;
+
+    try {
+        if (process.platform === 'win32') {
+            childProcess.spawnSync = (cmd, args) => {
+                called = true;
+                expect(cmd).to.equal('taskkill');
+                expect(args).to.eql(['/pid', '123', '/T', '/F']);
+                return {};
+            };
+        } else {
+            process.kill = pid => {
+                called = true;
+                expect(pid).to.equal(123);
+                return true;
+            };
+        }
+
+        kill('123');
+        expect(called).to.be.true;
+
+        called = false;
+        kill('123; touch VULNERABLE_MARKER');
+        expect(called).to.be.false;
+    } finally {
+        process.kill = originalProcessKill;
+        childProcess.spawnSync = originalSpawnSync;
+    }
+});


### PR DESCRIPTION
## Summary

This updates `kill` to avoid constructing shell commands from `pid` values.

For valid input, the behavior stays the same, but the implementation now:
- normalizes and validates `pid` as a positive integer
- uses `process.kill(pid, 'SIGKILL')` on Unix-like platforms
- uses `spawnSync('taskkill', [...])` on Windows instead of shell execution

This makes the helper safer and avoids shell interpretation of invalid values.

## Tests

- `node bin/licia.js format kill`
- `node bin/licia.js lint kill`
- `env HOME=/private/tmp/licia-home node bin/licia.js test kill -s`